### PR TITLE
Add a GitHub Actions workflow to build all projects and run all tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build all projects
+        run: ./gradlew build
+
+      - name: Run all tests
+        run: ./gradlew check

--- a/buildSrc/src/main/kotlin/pk-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/pk-publish.gradle.kts
@@ -1,69 +1,96 @@
-val properties = java.util.Properties()
-properties.load(rootProject.file("local.properties").inputStream())
-
-val isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
-
 plugins {
     `maven-publish`
     signing
 }
 
+val localPropertiesFile = rootProject.file("local.properties")
 
-project.extra.set("signing.keyId", properties.getProperty("signing.keyId"))
-project.extra.set("signing.secretKeyRingFile", properties.getProperty("signing.secretKeyRingFile"))
-project.extra.set("signing.password", properties.getProperty("signing.password"))
+if (localPropertiesFile.exists()) {
+    val properties = java.util.Properties()
+    properties.load(localPropertiesFile.inputStream())
 
+    val signingKeyId = properties.getProperty("signing.keyId")
+    val signingSecretKeyRingFile = properties.getProperty("signing.secretKeyRingFile")
+    val signingPassword = properties.getProperty("signing.password")
 
-publishing {
+    val nexusPro = properties.getProperty("nexus.pro_url")
+    val nexusSnapshot = properties.getProperty("nexus.snap_url")
 
-    publications.configureEach {
-        if (this is MavenPublication) {
-            val publicName = "${rootProject.name} ${name.capitalize()}"
-            pom {
-                name.set(publicName)
-                description.set("Powerful Dependency Injector for Kotlin")
-                url.set("https://github.com/corbella83/PopKorn")
-                licenses {
-                    license {
-                        name.set("The Apache Software License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                        distribution.set("repo")
+    val nexusUsername = properties.getProperty("nexus.username")
+    val nexusPassword = properties.getProperty("nexus.password")
+
+    val publishingProperties = listOf(
+        signingKeyId,
+        signingSecretKeyRingFile,
+        signingPassword,
+        nexusPro,
+        nexusSnapshot,
+        nexusUsername,
+        nexusPassword
+    )
+
+    if (publishingProperties.all { property -> property != null }) {
+        val isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
+
+        project.extra.set("signing.keyId", signingKeyId)
+        project.extra.set("signing.secretKeyRingFile", signingSecretKeyRingFile)
+        project.extra.set("signing.password", signingPassword)
+
+        publishing {
+
+            publications.configureEach {
+                if (this is MavenPublication) {
+                    val publicName = "${rootProject.name} ${name.capitalize()}"
+                    pom {
+                        name.set(publicName)
+                        description.set("Powerful Dependency Injector for Kotlin")
+                        url.set("https://github.com/corbella83/PopKorn")
+                        licenses {
+                            license {
+                                name.set("The Apache Software License, Version 2.0")
+                                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                                distribution.set("repo")
+                            }
+                        }
+                        developers {
+                            developer {
+                                id.set("corbella83")
+                                name.set("Pau Corbella")
+                            }
+                        }
+                        scm {
+                            connection.set("scm:git:git://github.com/corbella83/PopKorn.git")
+                            developerConnection.set("scm:git:ssh://git@github.com/corbella83/PopKorn.git")
+                            url.set("https://github.com/corbella83/PopKorn")
+                        }
                     }
                 }
-                developers {
-                    developer {
-                        id.set("corbella83")
-                        name.set("Pau Corbella")
+            }
+
+            repositories {
+                maven {
+                    val releasesRepoUrl = uri(nexusPro)
+                    val snapshotsRepoUrl = uri(nexusSnapshot)
+                    url = if (isReleaseVersion) releasesRepoUrl else snapshotsRepoUrl
+                    credentials {
+                        username = nexusUsername
+                        password = nexusPassword
                     }
-                }
-                scm {
-                    connection.set("scm:git:git://github.com/corbella83/PopKorn.git")
-                    developerConnection.set("scm:git:ssh://git@github.com/corbella83/PopKorn.git")
-                    url.set("https://github.com/corbella83/PopKorn")
                 }
             }
         }
-    }
 
-    repositories {
-        maven {
-            val releasesRepoUrl = uri(properties.getProperty("nexus.pro_url"))
-            val snapshotsRepoUrl = uri(properties.getProperty("nexus.snap_url"))
-            url = if (isReleaseVersion) releasesRepoUrl else snapshotsRepoUrl
-            credentials {
-                username = properties.getProperty("nexus.username")
-                password = properties.getProperty("nexus.password")
-            }
+        tasks.withType<Sign>().configureEach {
+            onlyIf { isReleaseVersion }
         }
+
+        signing {
+            sign(publishing.publications)
+        }
+    } else {
+        println(
+            "Warning: One or more properties required to publish `${project.name}` to Maven Central has not been " +
+                    "added to local.properties file"
+        )
     }
-
 }
-
-tasks.withType<Sign>().configureEach {
-    onlyIf { isReleaseVersion }
-}
-
-signing {
-    sign(publishing.publications)
-}
-


### PR DESCRIPTION
To be able to build all projects the `pk-publish` precompiled plugin was forcing the usage of a `local.properties` file plus multiple properties.

Now this file is optional (necessary for GitHub Actions because it doesn't exist). And if it exists and some property is missing (for example, `local.properties` is automatically created in Windows), the projects build instead of failing.

This allows to the contributors build all projects without having to use fake properties in `local.properties`.