### PR TITLE
Windows Improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [ macOS-latest, windows-latest, ubuntu-latest ]
+
+    runs-on: ${{matrix.os}}
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Change Log
 Version 2.2.0 *(2021-XX-XX)*
 -----------------------------
 
-* 
+* Fix: Compilation error when compiling on Windows OS
 
 Version 2.1.0 *(2021-01-19)*
 -----------------------------
@@ -73,4 +73,3 @@ Version 1.0.1 *(2019-11-20)*
 
 * Fix: Internal dependencies are now being resolved
 * New: addInjectable(instance) can define the injectable class as any of the parents
-    

--- a/popkorn-compiler/src/main/kotlin/cc/popkorn/compiler/generators/MappingGenerator.kt
+++ b/popkorn-compiler/src/main/kotlin/cc/popkorn/compiler/generators/MappingGenerator.kt
@@ -70,7 +70,7 @@ internal class MappingGenerator(private val directory: File, private val filer: 
     }
 
     private fun getModuleName(): String {
-        val split = directory.absolutePath.split("/")
+        val split = directory.absolutePath.split(File.separatorChar)
         split.forEachIndexed { index, s ->
             if (s == "build") return split[index - 1].replace(Regex("[^a-zA-Z0-9]"), "").capitalize()
         }

--- a/popkorn/build.gradle.kts
+++ b/popkorn/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
     linuxX64()
     linuxArm64()
     macosX64()
+    mingwX64()
 
     sourceSets {
         val commonMain by getting {
@@ -82,21 +83,25 @@ kotlin {
         val linuxX64Main by getting
         val linuxArm64Main by getting
         val macosX64Main by getting
+        val mingwX64Main by getting
         val nativeMain by creating {
             dependsOn(commonMain)
             linuxX64Main.dependsOn(this)
             linuxArm64Main.dependsOn(this)
             macosX64Main.dependsOn(this)
+            mingwX64Main.dependsOn(this)
         }
 
         val linuxX64Test by getting
         val linuxArm64Test by getting
         val macosX64Test by getting
+        val mingwX64Test by getting
         val nativeTest by creating {
             dependsOn(commonTest)
             linuxX64Test.dependsOn(this)
             linuxArm64Test.dependsOn(this)
             macosX64Test.dependsOn(this)
+            mingwX64Test.dependsOn(this)
         }
     }
 


### PR DESCRIPTION
- Fix a bug when using PopKorn on Windows machines
- Check PopKorn works in all machines via GitHub Actions
- Enable Windows x64 target

To publish PopKorn in MavenCentral with all target we will need a new GitHub Action which uses a Matrix (macOS and Windows OS at least) so we can get all artifacts (macOS + iOS + Windows + Linux + JVM)